### PR TITLE
Support pam-auth-update

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,9 @@ Package: libpam-u2f
 Architecture: any
 Breaks: pamu2fcfg (<< 1.0.4-0.2)
 Replaces: pamu2fcfg (<< 1.0.4-0.2)
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: debconf | debconf-2.0,
+	 ${shlibs:Depends},
+	 ${misc:Depends}
 Recommends: pamu2fcfg
 Description: universal 2nd factor (U2F) PAM module
  Universal 2nd Factor (U2F) is an authentication mechanism that strengthen

--- a/debian/libpam-u2f.config
+++ b/debian/libpam-u2f.config
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+. /usr/share/debconf/confmodule
+
+db_beginblock
+db_input medium libpam-u2f/type || true
+db_input medium libpam-u2f/args || true
+db_endblock
+
+db_go
+
+#DEBHELPER#

--- a/debian/libpam-u2f.postinst
+++ b/debian/libpam-u2f.postinst
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -e
+
+. /usr/share/debconf/confmodule
+
+db_get libpam-u2f/type
+AUTHTYPE="$RET"
+
+db_get libpam-u2f/args
+ARGS="$RET"
+
+case "${AUTHTYPE}" in
+	Additional)
+		CONTROL="required"
+		;;
+	*)
+		CONTROL="[success=end default=ignore]"
+		;;
+esac
+
+cat << EOF > /usr/share/pam-configs/pam-u2f
+Name: FIDO2/U2F authentication using pam-u2f
+Default: no
+Priority: 384
+Auth-Type: $AUTHTYPE
+Auth:
+	$CONTROL	pam_u2f.so	$ARGS
+Auth-Initial:
+	$CONTROL	pam_u2f.so	$ARGS
+EOF
+
+pam-auth-update --package
+
+#DEBHELPER#

--- a/debian/libpam-u2f.postrm
+++ b/debian/libpam-u2f.postrm
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = "purge" ] && [ -e /usr/share/debconf/confmodule ]; then
+	. /usr/share/debconf/confmodule
+	db_purge
+fi
+
+if [ "$1" = "remove" ]; then
+	rm -f /usr/share/pam-configs/pam-u2f
+fi
+
+#DEBHELPER#

--- a/debian/libpam-u2f.postrm
+++ b/debian/libpam-u2f.postrm
@@ -1,11 +1,6 @@
 #!/bin/sh
 set -e
 
-if [ "$1" = "purge" ] && [ -e /usr/share/debconf/confmodule ]; then
-	. /usr/share/debconf/confmodule
-	db_purge
-fi
-
 if [ "$1" = "remove" ]; then
 	rm -f /usr/share/pam-configs/pam-u2f
 fi

--- a/debian/libpam-u2f.prerm
+++ b/debian/libpam-u2f.prerm
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = "remove" ]; then
+	pam-auth-update --package --remove pam-u2f
+fi
+
+#DEBHELPER#

--- a/debian/libpam-u2f.templates
+++ b/debian/libpam-u2f.templates
@@ -1,0 +1,16 @@
+Template: libpam-u2f/type
+Type: select
+Choices: Primary, Additional
+Default: Primary
+Description: Authentication type:
+ The pam-u2f module can be configured as either a Primary or Additional
+ (second) factor for authentication. As a Primary factor, failure to
+ authenticate may cause PAM to fallback to another lower priority method. As
+ either factor, higher priority modules may preempt pam-u2f altogether.
+
+Template: libpam-u2f/args
+Type: string
+Default: cue
+Description: Module options:
+ The behavior of pam-u2f can be further customized using a space-separated list
+ of options. Available options are described in the pam_u2f(8) manual page.


### PR DESCRIPTION
Allow pam-u2f to be configured either in the Primary or Additional
substack via debconf (`dpkg-reconfigure libpam-u2f`).

Closes #4.